### PR TITLE
Make relative path to nspBuild.exe explicit

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -14,7 +14,7 @@ import (
 //go:embed nspBuild.exe
 var binary []byte
 
-const nspBuildExecutable = "nspBuild.exe"
+const nspBuildExecutable = "./nspBuild.exe"
 
 func extractNcaFilesPath(directoryPath string) []string {
 	filesPath := make([]string, 0)


### PR DESCRIPTION
This fixes compatibility with Go 1.19+: https://tip.golang.org/doc/go1.19#os-exec-path

Closes #1.